### PR TITLE
Add support for constructor signatures (second try, see #2)

### DIFF
--- a/Eltons.ReflectionKit.Tests/Examples.cs
+++ b/Eltons.ReflectionKit.Tests/Examples.cs
@@ -5,16 +5,25 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using Eltons.ReflectionKit;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Eltons.ReflectionKit.Tests
 {
+    public static class TestExtensionMethods
+    {
+        public static string ExtensionMethod(this string firstParam, bool secondParam)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
     [TestClass]
     public class Examples
     {
         [TestMethod]
-        public void Example_Signature() {
+        public void Example_Signature()
+        {
             var type = typeof(Examples);
             var method = type.GetMethod(nameof(TestMethod));
 
@@ -24,57 +33,8 @@ namespace Eltons.ReflectionKit.Tests
         }
 
         [TestMethod]
-        public void Example_Signature_Invokable() {
-            var type = typeof(Examples);
-            var method = type.GetMethod(nameof(TestMethod));
-
-            var signature = method.GetSignature(true);
-
-            Assert.AreEqual("TestMethod(firstParam)", signature);
-        }
-
-        [TestMethod]
-        public void Example_Signature_Generics() {
-            var type  = typeof(Examples);
-            var method = type.GetMethod(nameof(TestMethod2));
-
-            var signature = method.GetSignature(false);
-
-            Assert.AreEqual("public System.Collections.Generic.List<string> TestMethod2<T>(string firstParam, T secondParam)", signature);
-        }
-
-        [TestMethod]
-        public void Example_Signature_Generics_Invokable() {
-            var type  = typeof(Examples);
-            var method = type.GetMethod(nameof(TestMethod2));
-
-            var signature = method.GetSignature(true);
-
-            Assert.AreEqual("TestMethod2<T>(firstParam, secondParam)", signature);
-        }
-
-        [TestMethod]
-        public void Example_Signature_Generics_Nested() {
-            var type = typeof(Examples);
-            var method = type.GetMethod(nameof(TestMethod3));
-
-            var signature = method.GetSignature(false);
-
-            Assert.AreEqual("public void TestMethod3(System.Action<System.Action<System.Action<string>>> firstParam)", signature);
-        }
-
-        [TestMethod]
-        public void Example_Signature_Nullable() {
-            var type = typeof(Examples);
-            var method = type.GetMethod(nameof(TestMethod4));
-
-            var signature = method.GetSignature(false);
-
-            Assert.AreEqual("public void TestMethod4(int? firstParam)", signature);
-        }
-
-        [TestMethod]
-        public void Example_Signature_Accessor() {
+        public void Example_Signature_Accessor()
+        {
             var type = typeof(Examples);
             var method = type.GetMethod(nameof(TestMethod5), BindingFlags.Static | BindingFlags.NonPublic);
 
@@ -84,7 +44,8 @@ namespace Eltons.ReflectionKit.Tests
         }
 
         [TestMethod]
-        public void Example_Signature_ExtensionMethod() {
+        public void Example_Signature_ExtensionMethod()
+        {
             var type = typeof(TestExtensionMethods);
             var method = type.GetMethod(nameof(TestExtensionMethods.ExtensionMethod));
 
@@ -94,7 +55,8 @@ namespace Eltons.ReflectionKit.Tests
         }
 
         [TestMethod]
-        public void Example_Signature_ExtensionMethod_Invokable() {
+        public void Example_Signature_ExtensionMethod_Invokable()
+        {
             var type = typeof(TestExtensionMethods);
             var method = type.GetMethod(nameof(TestExtensionMethods.ExtensionMethod));
 
@@ -103,31 +65,83 @@ namespace Eltons.ReflectionKit.Tests
             Assert.AreEqual("ExtensionMethod(secondParam)", signature);
         }
 
-        public string TestMethod(string firstParam) {
+        [TestMethod]
+        public void Example_Signature_Generics()
+        {
+            var type = typeof(Examples);
+            var method = type.GetMethod(nameof(TestMethod2));
+
+            var signature = method.GetSignature(false);
+
+            Assert.AreEqual("public System.Collections.Generic.List<string> TestMethod2<T>(string firstParam, T secondParam)", signature);
+        }
+
+        [TestMethod]
+        public void Example_Signature_Generics_Invokable()
+        {
+            var type = typeof(Examples);
+            var method = type.GetMethod(nameof(TestMethod2));
+
+            var signature = method.GetSignature(true);
+
+            Assert.AreEqual("TestMethod2<T>(firstParam, secondParam)", signature);
+        }
+
+        [TestMethod]
+        public void Example_Signature_Generics_Nested()
+        {
+            var type = typeof(Examples);
+            var method = type.GetMethod(nameof(TestMethod3));
+
+            var signature = method.GetSignature(false);
+
+            Assert.AreEqual("public void TestMethod3(System.Action<System.Action<System.Action<string>>> firstParam)", signature);
+        }
+
+        [TestMethod]
+        public void Example_Signature_Invokable()
+        {
+            var type = typeof(Examples);
+            var method = type.GetMethod(nameof(TestMethod));
+
+            var signature = method.GetSignature(true);
+
+            Assert.AreEqual("TestMethod(firstParam)", signature);
+        }
+
+        [TestMethod]
+        public void Example_Signature_Nullable()
+        {
+            var type = typeof(Examples);
+            var method = type.GetMethod(nameof(TestMethod4));
+
+            var signature = method.GetSignature(false);
+
+            Assert.AreEqual("public void TestMethod4(int? firstParam)", signature);
+        }
+
+        public string TestMethod(string firstParam)
+        {
             throw new NotImplementedException();
         }
 
-        public List<string> TestMethod2<T>(string firstParam, T secondParam) {
+        public List<string> TestMethod2<T>(string firstParam, T secondParam)
+        {
             throw new NotImplementedException();
         }
 
-        public void TestMethod3(System.Action<System.Action<System.Action<string>>> firstParam) {
+        public void TestMethod3(System.Action<System.Action<System.Action<string>>> firstParam)
+        {
             throw new NotImplementedException();
         }
 
-        public void TestMethod4(Nullable<int> firstParam) {
+        public void TestMethod4(Nullable<int> firstParam)
+        {
             throw new NotImplementedException();
         }
 
-        internal static void TestMethod5() {
-
-        }
-    }
-
-    public static class TestExtensionMethods
-    {
-        public static string ExtensionMethod(this string firstParam, bool secondParam) {
-            throw new NotImplementedException();
+        internal static void TestMethod5()
+        {
         }
     }
 }

--- a/Eltons.ReflectionKit.Tests/Examples.cs
+++ b/Eltons.ReflectionKit.Tests/Examples.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -21,6 +22,22 @@ namespace Eltons.ReflectionKit.Tests
     [TestClass]
     public class Examples
     {
+        public Examples(int param)
+        {
+        }
+
+        public Examples()
+        {
+        }
+
+        protected Examples(int param1, int param2)
+        {
+        }
+
+        private Examples(int param1, int param2, int param3)
+        {
+        }
+
         [TestMethod]
         public void Example_Signature()
         {
@@ -44,12 +61,45 @@ namespace Eltons.ReflectionKit.Tests
         }
 
         [TestMethod]
+        public void Example_Signature_Constructor()
+        {
+            var type = typeof(Examples);
+            var method = type.GetConstructors((BindingFlags)~0).Single(ctor => ctor.GetParameters().Count() == 1);
+
+            var signature = method.GetSignature(false);
+
+            Assert.AreEqual("public Examples(int param)", signature);
+        }
+
+        [TestMethod]
+        public void Example_Signature_Constructor_WithPrivateAccessor()
+        {
+            var type = typeof(Examples);
+            var method = type.GetConstructors((BindingFlags)~0).Single(ctor => ctor.GetParameters().Count() == 3);
+
+            var signature = method.GetSignature(false);
+
+            Assert.AreEqual("private Examples(int param1, int param2, int param3)", signature);
+        }
+
+        [TestMethod]
+        public void Example_Signature_Constructor_WithProtectedAccessor()
+        {
+            var type = typeof(Examples);
+            var method = type.GetConstructors((BindingFlags)~0).Single(ctor => ctor.GetParameters().Count() == 2);
+
+            var signature = method.GetSignature(false);
+
+            Assert.AreEqual("protected Examples(int param1, int param2)", signature);
+        }
+
+        [TestMethod]
         public void Example_Signature_ExtensionMethod()
         {
             var type = typeof(TestExtensionMethods);
             var method = type.GetMethod(nameof(TestExtensionMethods.ExtensionMethod));
 
-            var signature = method.GetSignature(false);
+            var signature = method.GetSignature(true);
 
             Assert.AreEqual("public static string ExtensionMethod(this string firstParam, bool secondParam)", signature);
         }
@@ -93,7 +143,7 @@ namespace Eltons.ReflectionKit.Tests
             var type = typeof(Examples);
             var method = type.GetMethod(nameof(TestMethod3));
 
-            var signature = method.GetSignature(false);
+            var signature = method.GetSignature(true);
 
             Assert.AreEqual("public void TestMethod3(System.Action<System.Action<System.Action<string>>> firstParam)", signature);
         }
@@ -104,7 +154,7 @@ namespace Eltons.ReflectionKit.Tests
             var type = typeof(Examples);
             var method = type.GetMethod(nameof(TestMethod));
 
-            var signature = method.GetSignature(true);
+            var signature = method.GetSignature(false);
 
             Assert.AreEqual("TestMethod(firstParam)", signature);
         }

--- a/Eltons.ReflectionKit.Tests/Examples.cs
+++ b/Eltons.ReflectionKit.Tests/Examples.cs
@@ -99,7 +99,7 @@ namespace Eltons.ReflectionKit.Tests
             var type = typeof(TestExtensionMethods);
             var method = type.GetMethod(nameof(TestExtensionMethods.ExtensionMethod));
 
-            var signature = method.GetSignature(true);
+            var signature = method.GetSignature(false);
 
             Assert.AreEqual("public static string ExtensionMethod(this string firstParam, bool secondParam)", signature);
         }
@@ -143,7 +143,7 @@ namespace Eltons.ReflectionKit.Tests
             var type = typeof(Examples);
             var method = type.GetMethod(nameof(TestMethod3));
 
-            var signature = method.GetSignature(true);
+            var signature = method.GetSignature(false);
 
             Assert.AreEqual("public void TestMethod3(System.Action<System.Action<System.Action<string>>> firstParam)", signature);
         }
@@ -154,7 +154,7 @@ namespace Eltons.ReflectionKit.Tests
             var type = typeof(Examples);
             var method = type.GetMethod(nameof(TestMethod));
 
-            var signature = method.GetSignature(false);
+            var signature = method.GetSignature(true);
 
             Assert.AreEqual("TestMethod(firstParam)", signature);
         }

--- a/Eltons.ReflectionKit.Tests/Requirement.cs
+++ b/Eltons.ReflectionKit.Tests/Requirement.cs
@@ -7,18 +7,19 @@ using System.Reflection;
 
 namespace Eltons.ReflectionKit.Tests
 {
-    public class Requirement
+    public static class RequirmentExtensionMethods
     {
-        [Requirement("public void CanReturnVoid()", "CanReturnVoid()")]
-        public void CanReturnVoid() {
-
+        public static RequirementAttribute GetRequirement(this MethodInfo method)
+        {
+            return method.GetCustomAttribute<RequirementAttribute>();
         }
     }
 
-    public static class RequirmentExtensionMethods
+    public class Requirement
     {
-        public static RequirementAttribute GetRequirement(this MethodInfo method) {
-            return method.GetCustomAttribute<RequirementAttribute>();
+        [Requirement("public void CanReturnVoid()", "CanReturnVoid()")]
+        public void CanReturnVoid()
+        {
         }
     }
 
@@ -27,12 +28,14 @@ namespace Eltons.ReflectionKit.Tests
         AllowMultiple = false)]
     public sealed class RequirementAttribute : Attribute
     {
-        public RequirementAttribute(string expectedSignature, string expectedInvokeableSignature) {
+        public RequirementAttribute(string expectedSignature, string expectedInvokeableSignature)
+        {
             ExpectedSignature = expectedSignature;
             ExpectedInvokeableSignature = expectedInvokeableSignature;
         }
 
-        public string ExpectedSignature { get; set; }
         public string ExpectedInvokeableSignature { get; set; }
+
+        public string ExpectedSignature { get; set; }
     }
 }

--- a/Eltons.ReflectionKit/ConstructorInfoExtensionMethods.cs
+++ b/Eltons.ReflectionKit/ConstructorInfoExtensionMethods.cs
@@ -6,11 +6,11 @@ using System.Reflection;
 
 namespace Eltons.ReflectionKit
 {
-    public static class MethodExtensionMethods
+    public static class ConstructorInfoExtensionMethods
     {
-        public static string GetSignature(this MethodInfo method, bool isInvokable)
+        public static string GetSignature(this ConstructorInfo constructor, bool isInvokable)
         {
-            return new MethodSignature().Build(method, isInvokable);
+            return new ConstructorMethodSignature().Build(constructor, isInvokable);
         }
     }
 }

--- a/Eltons.ReflectionKit/ConstructorMethodSignature.cs
+++ b/Eltons.ReflectionKit/ConstructorMethodSignature.cs
@@ -2,16 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-using System;
-using System.Linq;
 using System.Reflection;
 using System.Text;
 
 namespace Eltons.ReflectionKit
 {
-    public class MethodSignature : MethodBaseSignature
+    public class ConstructorMethodSignature : MethodBaseSignature
     {
-        public string Build(MethodInfo method, bool invokable)
+        public string Build(ConstructorInfo method, bool invokable)
         {
             var signatureBuilder = new StringBuilder();
 
@@ -19,12 +17,10 @@ namespace Eltons.ReflectionKit
             if (!invokable)
             {
                 signatureBuilder.Append(BuildAccessor(method));
-                signatureBuilder.Append(TypeSignature.Build(method.ReturnType));
-                signatureBuilder.Append(" ");
             }
 
             // Add method name
-            signatureBuilder.Append(method.Name);
+            signatureBuilder.Append(method.DeclaringType.Name);
 
             // Add method generics
             if (method.IsGenericMethod)

--- a/Eltons.ReflectionKit/MethodBaseSignature.cs
+++ b/Eltons.ReflectionKit/MethodBaseSignature.cs
@@ -1,0 +1,89 @@
+﻿/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Eltons.ReflectionKit
+{
+    public abstract class MethodBaseSignature
+    {
+        public string BuildAccessor(MethodBase method)
+        {
+            string signature = null;
+
+            if (method.IsAssembly)
+            {
+                signature = "internal ";
+
+                if (method.IsFamily)
+                    signature += "protected ";
+            }
+            else if (method.IsPublic)
+            {
+                signature = "public ";
+            }
+            else if (method.IsPrivate)
+            {
+                signature = "private ";
+            }
+            else if (method.IsFamily)
+            {
+                signature = "protected ";
+            }
+
+            if (method.IsStatic)
+                signature += "static ";
+
+            return signature;
+        }
+
+        public string BuildArguments(MethodBase method, bool invokable)
+        {
+            var isExtensionMethod = method.IsDefined(typeof(System.Runtime.CompilerServices.ExtensionAttribute), false);
+            var methodParameters = method.GetParameters().AsEnumerable();
+
+            // If this signature is designed to be invoked and it's an extension method
+            if (isExtensionMethod && invokable)
+            {
+                // Skip the first argument
+                methodParameters = methodParameters.Skip(1);
+            }
+
+            var methodParameterSignatures = methodParameters.Select(param =>
+            {
+                var signature = string.Empty;
+
+                if (param.ParameterType.IsByRef)
+                    signature = "ref ";
+                else if (param.IsOut)
+                    signature = "out ";
+                else if (isExtensionMethod && param.Position == 0)
+                    signature = "this ";
+
+                if (!invokable)
+                {
+                    signature += TypeSignature.Build(param.ParameterType) + " ";
+                }
+
+                signature += param.Name;
+
+                return signature;
+            });
+
+            var methodParameterString = "(" + string.Join(", ", methodParameterSignatures) + ")";
+
+            return methodParameterString;
+        }
+
+        public string BuildGenerics(MethodBase method)
+        {
+            if (method == null) throw new ArgumentNullException(nameof(method));
+            if (!method.IsGenericMethod) throw new ArgumentException($"{method.Name} is not generic.");
+
+            return TypeSignature.BuildGenerics(method.GetGenericArguments());
+        }
+    }
+}

--- a/Eltons.ReflectionKit/MethodExtensionMethods.cs
+++ b/Eltons.ReflectionKit/MethodExtensionMethods.cs
@@ -8,7 +8,8 @@ namespace Eltons.ReflectionKit
 {
     public static class MethodExtensionMethods
     {
-        public static string GetSignature(this MethodInfo method, bool isInvokable) {
+        public static string GetSignature(this MethodInfo method, bool isInvokable)
+        {
             return MethodSignature.Build(method, isInvokable);
         }
     }

--- a/Eltons.ReflectionKit/MethodSignature.cs
+++ b/Eltons.ReflectionKit/MethodSignature.cs
@@ -2,20 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-using System.Text;
+using System;
 using System.Linq;
 using System.Reflection;
-using System;
+using System.Text;
 
 namespace Eltons.ReflectionKit
 {
     public static class MethodSignature
     {
-        public static string Build(MethodInfo method, bool invokable) {
+        public static string Build(MethodInfo method, bool invokable)
+        {
             var signatureBuilder = new StringBuilder();
 
             // Add our method accessors if it's not invokable
-            if (!invokable) {
+            if (!invokable)
+            {
                 signatureBuilder.Append(BuildAccessor(method));
                 signatureBuilder.Append(TypeSignature.Build(method.ReturnType));
                 signatureBuilder.Append(" ");
@@ -25,7 +27,8 @@ namespace Eltons.ReflectionKit
             signatureBuilder.Append(method.Name);
 
             // Add method generics
-            if (method.IsGenericMethod) {
+            if (method.IsGenericMethod)
+            {
                 signatureBuilder.Append(BuildGenerics(method));
             }
 
@@ -35,19 +38,27 @@ namespace Eltons.ReflectionKit
             return signatureBuilder.ToString();
         }
 
-        public static string BuildAccessor(MethodInfo method) {
+        public static string BuildAccessor(MethodInfo method)
+        {
             string signature = null;
 
-            if (method.IsAssembly) {
+            if (method.IsAssembly)
+            {
                 signature = "internal ";
 
                 if (method.IsFamily)
                     signature += "protected ";
-            } else if (method.IsPublic) {
+            }
+            else if (method.IsPublic)
+            {
                 signature = "public ";
-            } else if (method.IsPrivate) {
+            }
+            else if (method.IsPrivate)
+            {
                 signature = "private ";
-            } else if (method.IsFamily) {
+            }
+            else if (method.IsFamily)
+            {
                 signature = "protected ";
             }
 
@@ -57,24 +68,20 @@ namespace Eltons.ReflectionKit
             return signature;
         }
 
-        public static string BuildGenerics(MethodInfo method) {
-            if (method == null) throw new ArgumentNullException(nameof(method));
-            if (!method.IsGenericMethod) throw new ArgumentException($"{method.Name} is not generic.");
-
-            return TypeSignature.BuildGenerics(method.GetGenericArguments());
-        }
-
-        public static string BuildArguments(MethodInfo method, bool invokable) {
+        public static string BuildArguments(MethodInfo method, bool invokable)
+        {
             var isExtensionMethod = method.IsDefined(typeof(System.Runtime.CompilerServices.ExtensionAttribute), false);
             var methodParameters = method.GetParameters().AsEnumerable();
 
             // If this signature is designed to be invoked and it's an extension method
-            if (isExtensionMethod && invokable) {
+            if (isExtensionMethod && invokable)
+            {
                 // Skip the first argument
                 methodParameters = methodParameters.Skip(1);
             }
 
-            var methodParameterSignatures = methodParameters.Select(param => {
+            var methodParameterSignatures = methodParameters.Select(param =>
+            {
                 var signature = string.Empty;
 
                 if (param.ParameterType.IsByRef)
@@ -84,7 +91,8 @@ namespace Eltons.ReflectionKit
                 else if (isExtensionMethod && param.Position == 0)
                     signature = "this ";
 
-                if (!invokable) {
+                if (!invokable)
+                {
                     signature += TypeSignature.Build(param.ParameterType) + " ";
                 }
 
@@ -96,6 +104,14 @@ namespace Eltons.ReflectionKit
             var methodParameterString = "(" + string.Join(", ", methodParameterSignatures) + ")";
 
             return methodParameterString;
+        }
+
+        public static string BuildGenerics(MethodInfo method)
+        {
+            if (method == null) throw new ArgumentNullException(nameof(method));
+            if (!method.IsGenericMethod) throw new ArgumentException($"{method.Name} is not generic.");
+
+            return TypeSignature.BuildGenerics(method.GetGenericArguments());
         }
     }
 }

--- a/Eltons.ReflectionKit/TypeExtensionMethods.cs
+++ b/Eltons.ReflectionKit/TypeExtensionMethods.cs
@@ -8,19 +8,21 @@ namespace Eltons.ReflectionKit
 {
     public static class TypeExtensionMethods
     {
-        public static bool IsNullable(this Type type, out Type underlyingType) {
-            underlyingType = Nullable.GetUnderlyingType(type);
-            return underlyingType != null;
-        }
-
         /// <summary>
         /// Is this type a generic type
         /// </summary>
         /// <param name="type"></param>
         /// <returns>True if generic, otherwise False</returns>
-        public static bool IsGeneric(this Type type) {
+        public static bool IsGeneric(this Type type)
+        {
             return type.IsGenericType
                 && type.Name.Contains("`");//TODO: Figure out why IsGenericType isn't good enough and document (or remove) this condition
+        }
+
+        public static bool IsNullable(this Type type, out Type underlyingType)
+        {
+            underlyingType = Nullable.GetUnderlyingType(type);
+            return underlyingType != null;
         }
     }
 }

--- a/Eltons.ReflectionKit/TypeSignature.cs
+++ b/Eltons.ReflectionKit/TypeSignature.cs
@@ -15,7 +15,8 @@ namespace Eltons.ReflectionKit
         /// </summary>
         /// <param name="type">Type. May be generic or <see cref="Nullable{T}"/></param>
         /// <returns>Fully qualified signature</returns>
-        public static string Build(Type type) {
+        public static string Build(Type type)
+        {
             var isNullableType = type.IsNullable(out var underlyingNullableType);
 
             var signatureType = isNullableType
@@ -26,12 +27,14 @@ namespace Eltons.ReflectionKit
 
             var signature = GetQualifiedTypeName(signatureType);
 
-            if (isGenericType) {
+            if (isGenericType)
+            {
                 // Add the generic arguments
                 signature += BuildGenerics(signatureType.GetGenericArguments());
             }
 
-            if (isNullableType) {
+            if (isNullableType)
+            {
                 signature += "?";
             }
 
@@ -43,7 +46,8 @@ namespace Eltons.ReflectionKit
         /// </summary>
         /// <param name="genericArgumentTypes"></param>
         /// <returns>Generic type signature like &lt;Type, ...&gt;</returns>
-        public static string BuildGenerics(IEnumerable<Type> genericArgumentTypes) {
+        public static string BuildGenerics(IEnumerable<Type> genericArgumentTypes)
+        {
             var argumentSignatures = genericArgumentTypes.Select(Build);
 
             return "<" + string.Join(", ", argumentSignatures) + ">";
@@ -55,18 +59,25 @@ namespace Eltons.ReflectionKit
         /// </summary>
         /// <param name="type"></param>
         /// <returns>The fully qualified name for <paramref name="type"/></returns>
-        public static string GetQualifiedTypeName(Type type) {
-            switch (type.Name) {
+        public static string GetQualifiedTypeName(Type type)
+        {
+            switch (type.Name)
+            {
                 case "String":
                     return "string";
+
                 case "Int32":
                     return "int";
+
                 case "Decimal":
                     return "decimal";
+
                 case "Object":
                     return "object";
+
                 case "Void":
                     return "void";
+
                 case "Boolean":
                     return "bool";
             }
@@ -76,19 +87,19 @@ namespace Eltons.ReflectionKit
                 ? type.Name
                 : type.FullName;
 
-            if(type.IsGeneric())
+            if (type.IsGeneric())
                 signature = RemoveGenericTypeNameArgumentCount(signature);
 
             return signature;
         }
-
 
         /// <summary>
         /// This removes the `{argumentcount} from a the signature of a generic type
         /// </summary>
         /// <param name="genericTypeSignature">Signature of a generic type</param>
         /// <returns><paramref name="genericTypeSignature"/> without any argument count</returns>
-        public static string RemoveGenericTypeNameArgumentCount(string genericTypeSignature) {
+        public static string RemoveGenericTypeNameArgumentCount(string genericTypeSignature)
+        {
             return genericTypeSignature.Substring(0, genericTypeSignature.IndexOf('`'));
         }
     }


### PR DESCRIPTION
Hey!

As requested I split up my reformatting into its own separate Commit (the first one).
Since I already created a PR and cannot switch the branch of that, I had to create a new one (this one).

The last two commits (40d300dadf1ac5f00cc6dd2ef0e46ea953792c85 and ad6a474e9fa35019cf99e65e7e00558d6bc7f721) are the interesting ones.

Here is the original conversation of the old PR #2:

Original description:

"Hey!

I found this project and really like it.
However, I saw that it was missing support for generating the signatures for constructors.

This PR adds support for generating signatures of ConstructorInfo (which can be obtained from Type.GetConstructors()) and streamlines the string builder across the different MethodBase implementations.

Hope you can update the NuGet package as well :)

Thanks for the work!"

Your response:

"Hey thanks a lot for leaving this pull request! It looks like it'll be a good addition. I haven't had a chance to fully look through the changes, but I do have one suggestion. If you can resolve this it would be really appreciated. If you can't it'll just take me a bit longer to review this and merge it in:
If you change the formatting or change the order of the methods, try and do that in its own commit. It makes it really difficult to diff the changes otherwise. If the logical changes are in one commit, and then any formatting is in another, it makes it 100 times easier to review.

This is what I see when I diff the commit. I don't think you made any changes to most of those tests, but git isn't smart enough to know that they moved, it thinks you changed the methods:"